### PR TITLE
feat: implement start method in SDKs

### DIFF
--- a/javascript/sdk_flowmetr/index.js
+++ b/javascript/sdk_flowmetr/index.js
@@ -2,6 +2,9 @@ class FlowMetr {
   url = "";
   project_token = "";
   flow_id = "";
+  node_id = "";
+  run_id = "";
+  logs = "";
   constructor(url, project_token, flow_id) {
     this.url = url;
     this.flow_id = flow_id;
@@ -11,6 +14,21 @@ class FlowMetr {
     console.log(`flow_id: ${this.flow_id}`);
     console.log(`project_token: ${this.project_token}`);
     console.log(`url: ${this.url}`);
+  }
+  start(node_id, run_id, logs) {
+    this.node_id = node_id;
+    this.run_id = run_id;
+    this.logs = logs;
+    const request_url = `https://flowmetr.com/hooks/${this.flow_id}?run_id=${this.run_id}&node_id=${this.node_id}&node_type=start&logs=${this.logs}&project_token=${this.project_token}`;
+    console.log(`request sent to: ${request_url}`);
+    fetch(request_url)
+      .then((response) => response.text())
+      .then((data) => {
+        console.log(`response: ${data}`);
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+      });
   }
 }
 module.exports = { FlowMetr };

--- a/javascript/test/test.js
+++ b/javascript/test/test.js
@@ -2,9 +2,15 @@ const { FlowMetr } = require("sdk_flowmetr"); // This imports your local SDK
 
 const flowmetr = new FlowMetr(
   (url = "https://FlowMetr.com"),
-  (flow_id = "339a7c52-58eb-4537-ab92-9a57f0bae96b"),
   (project_token =
-    "f815f37293f415e33e3b8542cc6eefa433809e1777774632f2343668792f3dd1")
+    "f815f37293f415e33e3b8542cc6eefa433809e1777774632f2343668792f3dd1"),
+  (flow_id = "339a7c52-58eb-4537-ab92-9a57f0bae96b")
 );
 
 flowmetr.test();
+
+flowmetr.start(
+  (node_id = "start-trigger"),
+  (run_id = "fa932b0f386f5d2e"),
+  (logs = "Started")
+);

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.egg-info
 build
+venv

--- a/python/flowmetr/core.py
+++ b/python/flowmetr/core.py
@@ -1,12 +1,24 @@
+import requests
+
 class FlowMetr:
     url = ""
     project_token = ""
     flow_id = ""
-    
+    node_id = ""
+    run_id = ""
+    logs = ""    
     def __init__(self, url, project_token, flow_id):
         self.url = url
         self.project_token = project_token
         self.flow_id = flow_id
+        
+    def start(self,node_id,run_id,logs):
+        self.node_id = node_id
+        self.run_id = run_id
+        self.logs = logs
+        res = requests.get(f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=start&logs={self.logs}&project_token={self.project_token}")
+        print(f"request sent to:{f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=start&logs={self.logs}&project_token={self.project_token}"}")
+        print(f"response:{res.text}")
     
     def test(self):
         print(f"flow_id: {self.flow_id}")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.9"
-dependencies = []
+dependencies = ["requests>=2.25.1"]
 
 
 [project.urls]

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -3,3 +3,5 @@ from flowmetr import FlowMetr
 flowmetr = FlowMetr(url="https://FlowMetr.com",flow_id="339a7c52-58eb-4537-ab92-9a57f0bae96b",project_token="f815f37293f415e33e3b8542cc6eefa433809e1777774632f2343668792f3dd1")
 
 flowmetr.test()
+
+flowmetr.start(node_id="start-trigger",run_id="fa932b0f386f5d2e",logs="Started")


### PR DESCRIPTION
Add Start Method to FlowMetr SDK

## Description
This change introduces the `start` method to both the JavaScript and Python FlowMetr SDKs. This method allows users to send data to the FlowMetr backend, including node ID, run ID, and logs, triggering specific actions within the FlowMetr platform.

## Changes Made
- Added `start` method to `FlowMetr` class in `javascript/sdk_flowmetr/index.js` and `python/sdk_flowmetr/core.py`.
- The `start` method constructs a URL with provided parameters and sends a GET request to the FlowMetr backend.
- Added `requests` dependency to `python/pyproject.toml`.
- Added example usage of the `start` method in `javascript/test/test.js` and `python/test/test.py`.
- Added `venv` to `.gitignore` in python.

## Type of Change
feat

## Testing
- Manually tested the `start` method in both JavaScript and Python environments by running the test files.
- Verified that the correct URL is constructed and a request is sent to the FlowMetr backend.
- Confirmed that the response from the backend is logged to the console.

## Notes for Reviewers
- Please verify the URL construction in the `start` method for correctness and security.
- Ensure that the error handling in the JavaScript `start` method is appropriate.
- Check the added dependency in `python/pyproject.toml`.