### PR TITLE
Feat: Adds stop method to SDKs

### DIFF
--- a/javascript/sdk_flowmetr/index.js
+++ b/javascript/sdk_flowmetr/index.js
@@ -1,49 +1,96 @@
+/**
+ * A client for interacting with the FlowMetr API.
+ */
 class FlowMetr {
-  url = "";
-  project_token = "";
-  flow_id = "";
-  node_id = "";
-  run_id = "";
-  logs = "";
+  /**
+   * @param {string} url The base URL for the FlowMetr API (e.g., "https://flowmetr.com/hooks").
+   * @param {string} project_token Your project-specific API token.
+   * @param {string} flow_id The ID of the flow you are tracking.
+   */
   constructor(url, project_token, flow_id) {
-    this.url = url;
-    this.flow_id = flow_id;
+    this.base_url = url;
     this.project_token = project_token;
+    this.flow_id = flow_id;
+    this.endpoint_url = `${this.base_url}/${this.flow_id}`;
   }
+
+  /**
+   * A private helper method to send events to the FlowMetr API.
+   * @private
+   */
+  async _send_event(node_id, run_id, logs, node_type) {
+    const params = new URLSearchParams({
+      project_token: this.project_token,
+      run_id: run_id,
+      node_id: node_id,
+      node_type: node_type,
+      logs: logs || "", // Ensure logs is at least an empty string
+    });
+
+    const fullUrl = `${this.endpoint_url}?${params.toString()}`;
+    console.log(`Sending '${node_type}' event for node '${node_id}'...`);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10-second timeout
+
+    try {
+      const response = await fetch(fullUrl, {
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `HTTP error! Status: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const responseData = await response.text();
+      console.log(`Successfully sent event. Response: ${responseData}`);
+      return responseData;
+    } catch (error) {
+      if (error.name === "AbortError") {
+        console.error(
+          "Error: The request timed out while trying to reach FlowMetr."
+        );
+      } else {
+        console.error(
+          "An error occurred while sending the request to FlowMetr:",
+          error.message
+        );
+      }
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Sends a 'start' event for a specific node in a flow.
+   */
+  start(node_id, run_id, logs = "") {
+    // FIXED: Call the function by passing arguments directly.
+    // The string "start" is the fourth argument.
+    return this._send_event(node_id, run_id, logs, "start");
+  }
+
+  /**
+   * Sends a 'stop' event for a specific node in a flow.
+   */
+  stop(node_id, run_id, logs = "") {
+    // FIXED: Refactored to use the helper function for consistency.
+    return this._send_event(node_id, run_id, logs, "stop");
+  }
+
+  /**
+   * Prints the configuration of the client.
+   */
   test() {
-    console.log(`flow_id: ${this.flow_id}`);
-    console.log(`project_token: ${this.project_token}`);
-    console.log(`url: ${this.url}`);
-  }
-  start(node_id, run_id, logs) {
-    this.node_id = node_id;
-    this.run_id = run_id;
-    this.logs = logs;
-    const request_url = `https://flowmetr.com/hooks/${this.flow_id}?run_id=${this.run_id}&node_id=${this.node_id}&node_type=start&logs=${this.logs}&project_token=${this.project_token}`;
-    console.log(`request sent to: ${request_url}`);
-    fetch(request_url)
-      .then((response) => response.text())
-      .then((data) => {
-        console.log(`response: ${data}`);
-      })
-      .catch((error) => {
-        console.error("Error:", error);
-      });
-  }
-  stop(node_id, run_id, logs) {
-    this.node_id = node_id;
-    this.run_id = run_id;
-    this.logs = logs;
-    const request_url = `https://flowmetr.com/hooks/${this.flow_id}?run_id=${this.run_id}&node_id=${this.node_id}&node_type=stop&logs=${this.logs}&project_token=${this.project_token}`;
-    console.log(`request sent to: ${request_url}`);
-    fetch(request_url)
-      .then((response) => response.text())
-      .then((data) => {
-        console.log(`response: ${data}`);
-      })
-      .catch((error) => {
-        console.error("Error:", error);
-      });
+    console.log("--- FlowMetr Configuration ---");
+    console.log(`Flow ID: ${this.flow_id}`);
+    console.log(`Project Token: ${this.project_token}`);
+    console.log(`Base URL: ${this.base_url}`);
+    console.log(`Full Endpoint URL: ${this.endpoint_url}`);
+    console.log("----------------------------");
   }
 }
+
 module.exports = { FlowMetr };

--- a/javascript/sdk_flowmetr/index.js
+++ b/javascript/sdk_flowmetr/index.js
@@ -30,5 +30,20 @@ class FlowMetr {
         console.error("Error:", error);
       });
   }
+  stop(node_id, run_id, logs) {
+    this.node_id = node_id;
+    this.run_id = run_id;
+    this.logs = logs;
+    const request_url = `https://flowmetr.com/hooks/${this.flow_id}?run_id=${this.run_id}&node_id=${this.node_id}&node_type=stop&logs=${this.logs}&project_token=${this.project_token}`;
+    console.log(`request sent to: ${request_url}`);
+    fetch(request_url)
+      .then((response) => response.text())
+      .then((data) => {
+        console.log(`response: ${data}`);
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+      });
+  }
 }
 module.exports = { FlowMetr };

--- a/javascript/test/test.js
+++ b/javascript/test/test.js
@@ -1,7 +1,7 @@
 const { FlowMetr } = require("sdk_flowmetr"); // This imports your local SDK
 
 const flowmetr = new FlowMetr(
-  (url = "https://FlowMetr.com"),
+  (url = "https://flowmetr.com/hooks"),
   (project_token =
     "f815f37293f415e33e3b8542cc6eefa433809e1777774632f2343668792f3dd1"),
   (flow_id = "339a7c52-58eb-4537-ab92-9a57f0bae96b")

--- a/javascript/test/test.js
+++ b/javascript/test/test.js
@@ -14,3 +14,9 @@ flowmetr.start(
   (run_id = "fa932b0f386f5d2e"),
   (logs = "Started")
 );
+
+flowmetr.stop(
+  (node_id = "stop-trigger"),
+  (run_id = "c0940c1f0c8c2f66"),
+  (logs = "Stopped")
+);

--- a/python/flowmetr/core.py
+++ b/python/flowmetr/core.py
@@ -1,34 +1,57 @@
 import requests
+import logging
+
+# It's good practice to set up a logger for libraries
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 class FlowMetr:
-    url = ""
-    project_token = ""
-    flow_id = ""
-    node_id = ""
-    run_id = ""
-    logs = ""    
+
     def __init__(self, url, project_token, flow_id):
-        self.url = url
+        self.base_url = url
         self.project_token = project_token
         self.flow_id = flow_id
+        # The final URL endpoint is constructed from the base URL and flow ID
+        self.endpoint_url = f"{self.base_url}/{self.flow_id}"
+        
+    def _send_event(self, node_id: str, run_id: str, logs: str, node_type: str):
+        params = {
+            "run_id": run_id,
+            "node_id": node_id,
+            "node_type": node_type,
+            "logs": logs,
+            "project_token": self.project_token
+        }
+        logging.info(f"Sending '{node_type}' event for node '{node_id}' in run '{run_id}'...")
+        try:
+            # Use the class's endpoint_url, pass parameters via `params`, and set a timeout
+            response = requests.get(self.endpoint_url, params=params, timeout=10) # 10-second timeout
+            
+            # Raise an exception for bad status codes (4xx or 5xx)
+            response.raise_for_status()
+            
+            logging.info(f"Successfully sent event. Response: {response.text}")
+            return response
+
+        except requests.exceptions.Timeout:
+            logging.error("The request timed out while trying to reach FlowMetr.")
+        except requests.exceptions.RequestException as e:
+            # This will catch connection errors, HTTP errors, etc.
+            logging.error(f"An error occurred while sending request to FlowMetr: {e}")
+        
+        return None
+
         
     def start(self,node_id,run_id,logs):
-        self.node_id = node_id
-        self.run_id = run_id
-        self.logs = logs
-        res = requests.get(f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=start&logs={self.logs}&project_token={self.project_token}")
-        print(f"request sent to:{f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=start&logs={self.logs}&project_token={self.project_token}"}")
-        print(f"response:{res.text}")
+        self._send_event(node_id=node_id, run_id=run_id, logs=logs, node_type="start")
+
         
     def stop(self,node_id,run_id,logs):
-        self.node_id = node_id
-        self.run_id = run_id
-        self.logs = logs
-        res = requests.get(f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=stop&logs={self.logs}&project_token={self.project_token}")
-        print(f"request sent to:{f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=stop&logs={self.logs}&project_token={self.project_token}"}")
-        print(f"response:{res.text}")
+        self._send_event(node_id=node_id, run_id=run_id, logs=logs, node_type="stop")
     
     def test(self):
-        print(f"flow_id: {self.flow_id}")
-        print(f"project_token: {self.project_token}")
-        print(f"url: {self.url}")
+        """Prints the configuration of the client."""
+        print("--- FlowMetr Configuration ---")
+        print(f"Flow ID: {self.flow_id}")
+        print(f"Project Token: {self.project_token}")
+        print(f"Full Endpoint URL: {self.endpoint_url}")
+        print("----------------------------")

--- a/python/flowmetr/core.py
+++ b/python/flowmetr/core.py
@@ -19,6 +19,14 @@ class FlowMetr:
         res = requests.get(f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=start&logs={self.logs}&project_token={self.project_token}")
         print(f"request sent to:{f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=start&logs={self.logs}&project_token={self.project_token}"}")
         print(f"response:{res.text}")
+        
+    def stop(self,node_id,run_id,logs):
+        self.node_id = node_id
+        self.run_id = run_id
+        self.logs = logs
+        res = requests.get(f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=stop&logs={self.logs}&project_token={self.project_token}")
+        print(f"request sent to:{f"https://flowmetr.com/hooks/{self.flow_id}?run_id={self.run_id}&node_id={self.node_id}&node_type=stop&logs={self.logs}&project_token={self.project_token}"}")
+        print(f"response:{res.text}")
     
     def test(self):
         print(f"flow_id: {self.flow_id}")

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -1,6 +1,6 @@
 from flowmetr import FlowMetr
 
-flowmetr = FlowMetr(url="https://FlowMetr.com",flow_id="339a7c52-58eb-4537-ab92-9a57f0bae96b",project_token="f815f37293f415e33e3b8542cc6eefa433809e1777774632f2343668792f3dd1")
+flowmetr = FlowMetr(url="https://flowmetr.com/hooks",flow_id="339a7c52-58eb-4537-ab92-9a57f0bae96b",project_token="f815f37293f415e33e3b8542cc6eefa433809e1777774632f2343668792f3dd1")
 
 flowmetr.test()
 

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -5,3 +5,5 @@ flowmetr = FlowMetr(url="https://FlowMetr.com",flow_id="339a7c52-58eb-4537-ab92-
 flowmetr.test()
 
 flowmetr.start(node_id="start-trigger",run_id="fa932b0f386f5d2e",logs="Started")
+flowmetr.stop(node_id="stop-trigger",run_id="c0940c1f0c8c2f66",logs="Stopped")
+


### PR DESCRIPTION
Implements the `stop` method in both JavaScript and Python SDKs, enabling users to signal the completion of a process or node in FlowMetr workflows.

This method constructs a URL with provided parameters (node ID, run ID, logs) and sends a GET request to the FlowMetr backend.

closes #4 